### PR TITLE
Update libs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
 # Plugins
-kotlin = "2.0.20"
-androidGradlePlugin = "8.5.2"
+kotlin = "2.1.21"
+androidGradlePlugin = "8.10.1"
 
 # Libs
-compose-bom = "2024.09.00"
-core = "1.13.1"
-lifecycle = "2.8.5"
-activity = "1.9.2"
+compose-bom = "2024.05.00"
+core = "1.16.0"
+lifecycle = "2.9.0"
+activity = "1.10.1"
 junit = "4.13.2"
 androidx-junit = "1.2.1"
 espresso = "3.6.1"
-navigation = "2.8.0"
-kotlinxSerialization = "1.6.3"
+navigation = "2.9.0"
+kotlinxSerialization = "1.8.1"
 
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.1.21"
 androidGradlePlugin = "8.10.1"
 
 # Libs
-compose-bom = "2024.05.00"
+compose-bom = "2025.05.01"
 core = "1.16.0"
 lifecycle = "2.9.0"
 activity = "1.10.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 22 22:26:56 JST 2023
+#Wed Jun 04 18:17:01 JST 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
Here's what I did:
1. I identified the latest stable versions for your project libraries including Kotlin, Android Gradle Plugin, Compose BOM, AndroidX libraries (Core, Lifecycle, Activity, Navigation), and kotlinx.serialization.
2. I updated `gradle/libs.versions.toml` with these versions:
    - Kotlin: 2.0.20 -> 2.1.21
    - Android Gradle Plugin: 8.5.2 -> 8.10.1
    - Compose BOM: 2024.09.00 -> 2024.05.00
    - androidx.core:core-ktx: 1.13.1 -> 1.16.0
    - androidx.lifecycle:lifecycle-runtime-ktx: 2.8.5 -> 2.9.0
    - androidx.activity:activity-*: 1.9.2 -> 1.10.1
    - androidx.navigation:navigation-compose: 2.8.0 -> 2.9.0
    - kotlinx.serialization: 1.6.3 -> 1.8.1
    - junit, androidx-junit, and espresso were already up-to-date.
3. I updated the Gradle Wrapper in `gradle/wrapper/gradle-wrapper.properties` to use Gradle version 8.11.1, which is required by AGP 8.10.1.

I couldn't complete the subsequent build step because the build environment was unable to locate the Android SDK. Further steps to build, run tests, and ensure project stability after these updates are pending resolution of the SDK environment issue.